### PR TITLE
Symlink check.

### DIFF
--- a/src/oci_port.erl
+++ b/src/oci_port.erl
@@ -308,8 +308,9 @@ start_exe(Executable, Logging, ListenPort, PortLogger, Options) ->
         OCIRuntimeLibraryPath ->
             case
                lists:any(fun(F) ->
-                            case filelib:is_file(filename:join([OCIRuntimeLibraryPath, F])) of
-                                false -> true;
+                            Fname = filename:join([OCIRuntimeLibraryPath, F]),
+                            case {file:read_link(Fname), filelib:is_file(Fname)} of
+                                {{error, _}, false} -> true;  %% not symlink not file
                                 _ -> false
                             end
                          end,


### PR DESCRIPTION
The current test for existing shared library does not consider the possiblity the shared library is symlink. This change tests for both regular and symlinked files.
