### PR TITLE
Support of C++11 (macro string concat).

### DIFF
--- a/c_src/erloci_lib/lib_interface.h
+++ b/c_src/erloci_lib/lib_interface.h
@@ -38,8 +38,8 @@ typedef enum _LOG_LEVEL {
 #define sprintf_s(_a, _b, _c, ...)				sprintf((_a), (_c), __VA_ARGS__)
 #define strncpy_s(_a, _b, _c, _d)               strncpy((_a), (_c), (_d))
 #define vsprintf_s(_a, _b, _c, _d)              vsprintf((_a), (_c), (_d))
-#define REMOTE_LOG_TERM(_level,_term,_str, ...)	if (log_flag) log_remote(__FILE__,__FUNCTION__,__LINE__,_level,_term,_str,##__VA_ARGS__)
-#define REMOTE_LOG(_level,_str, ...)			if (log_flag) log_remote(__FILE__,__FUNCTION__,__LINE__,_level,NULL,_str,##__VA_ARGS__)
+#define REMOTE_LOG_TERM(_level,_term,_str, ...)	if (log_flag) log_remote(__FILE__,__FUNCTION__,__LINE__,_level,_term, _str,##__VA_ARGS__)
+#define REMOTE_LOG(_level,_str, ...)			if (log_flag) log_remote(__FILE__,__FUNCTION__,__LINE__,_level,NULL, _str,##__VA_ARGS__)
 #define REMOTE_LOG_SINGLE(_str, ...)			if (log_flag) log_remote((_str),##__VA_ARGS__)
 #else
 #define REMOTE_LOG_TERM(_level,_term,_str, ...)	if (log_flag) log_remote(__FILE__,__FUNCTION__,__LINE__,_level,_term,_str,__VA_ARGS__)

--- a/c_src/erloci_lib/ocistmt.cpp
+++ b/c_src/erloci_lib/ocistmt.cpp
@@ -154,7 +154,7 @@ ocistmt::ocistmt(void *ocisess, OraText *stmt, size_t stmt_len)
 	checkerr(&r, OCIDescriptorAlloc(envhp,(dvoid **)&(cur_clm.row_valp),									\
 									__desctype, 0, (dvoid **)0));											\
 	if(r.fn_ret != SUCCESS) {																				\
-		REMOTE_LOG(ERR, "failed OCIDescriptorAlloc for %p column %d("__dtypestr")\n", _stmthp, num_cols);	\
+		REMOTE_LOG(ERR, "failed OCIDescriptorAlloc for %p column %d(" __dtypestr")\n", _stmthp, num_cols);	\
 		throw r;																							\
 	}																										\
 }
@@ -166,7 +166,7 @@ ocistmt::ocistmt(void *ocisess, OraText *stmt, size_t stmt_len)
 								(sword) cur_clm.dlen + 1, __datatype, &(cur_clm.indp), (ub2 *)0,			\
                                 (ub2 *)0, OCI_DEFAULT));													\
 	if(r.fn_ret != SUCCESS) {																				\
-		REMOTE_LOG(ERR, "failed OCIDefineByPos for %p column %d("__dtypestr")\n", _stmthp, num_cols);		\
+		REMOTE_LOG(ERR, "failed OCIDefineByPos for %p column %d(" __dtypestr")\n", _stmthp, num_cols);		\
 		throw r;																							\
 	}																										\
 }


### PR DESCRIPTION
C++11 [User-defined literals](http://en.cppreference.com/w/cpp/language/user_literal) breaks macros with string literal concatenation with space (e.g. `REMOTE_LOG`,  `OCIDEF` etc).

```c
"foo"__FILE__ // error
"foo" __FILE__ // fixed with a space
```

This required and introduced space doesn't effect the C MACRO string concatenation feature