### PR TITLE
Updated MacOS Makefile to use libnnz12

### DIFF
--- a/c_src/Makefile.osx
+++ b/c_src/Makefile.osx
@@ -25,8 +25,7 @@ ERLOCI_OBJS = $(ERLOCI_SRCS:.cpp=.o)
 
 CXXFLAGS = -ggdb -Wall -I$(ERL_INTERFACE_DIR)/include  -I$(ERLOCI_PATH) -I$(ERLOCI_LIB_PATH) -I$(OCI_INCLUDE_PATH)
 LINKDIRS = -L$(ERL_INTERFACE_DIR)/lib -L$(PRIV_DIR) -L$(OCI_LIB_PATH)
-#LINKFLAGS = -levent -lpthread -lerl_interface -lei -lerloci -locci -lons -lclntshcore -lclntsh -lnnz12 -lipc1 -lmql1
-LINKFLAGS = -levent -lpthread -lerl_interface -lei -lerloci -locci -lclntsh -lnnz11
+LINKFLAGS = -levent -lpthread -lerl_interface -lei -lerloci -locci -lclntsh -lnnz12
 
 all: $(PRIV_DIR) $(PRIV_DIR)/$(EXE_TARGET)
 	@echo "erloci compiled!!!"


### PR DESCRIPTION
This is being shipped now in the latest version of Instant Client for MacOS.